### PR TITLE
Fix integration test

### DIFF
--- a/test/rpg_quadrotor_integration_test/launch/rpg_quadrotor_integration_test.launch
+++ b/test/rpg_quadrotor_integration_test/launch/rpg_quadrotor_integration_test.launch
@@ -3,14 +3,15 @@
 
   <include file="$(find rpg_rotors_interface)/launch/quadrotor_empty_world.launch">
     <arg name="quad_name" value="$(arg quad_name)"/>
+    <arg name="enable_command_feedthrough" value="True"/>
   </include>
 
   <group ns="$(arg quad_name)" >
 
-    <test pkg="rpg_quadrotor_integration_test" 
-        test-name="rpg_quadrotor_integration_test" 
+    <test pkg="rpg_quadrotor_integration_test"
+        test-name="rpg_quadrotor_integration_test"
         type="rpg_quadrotor_integration_test" time-limit="120.0" />
-    
+
   </group>
 
 </launch>


### PR DESCRIPTION
The integration test was not allowed to feedthrough control commands and hence always failed because of that. This fixes it by setting the corresponding flag in its launch file to True.

@kohlerj Could you please check why merging was possible previously even though the integration test failed?