### PR TITLE
Reduce Latency of State Estimate Callback

### DIFF
--- a/control/autopilot/include/autopilot/autopilot_inl.h
+++ b/control/autopilot/include/autopilot/autopilot_inl.h
@@ -50,7 +50,7 @@ AutoPilot<Tcontroller, Tparams>::AutoPilot(const ros::NodeHandle& nh, const ros:
 
   // Subscribers
   state_estimate_sub_ = nh_.subscribe("autopilot/state_estimate", 1,
-    &AutoPilot<Tcontroller, Tparams>::stateEstimateCallback, this);
+    &AutoPilot<Tcontroller, Tparams>::stateEstimateCallback, this, ros::TransportHints().tcpNoDelay());
   low_level_feedback_sub_ = nh_.subscribe("low_level_feedback", 1,
     &AutoPilot<Tcontroller, Tparams>::lowLevelFeedbackCallback, this);
 


### PR DESCRIPTION
When running `roslaunch rpg_rotors_interface quadrotor_empty_world.launch`, I experience significant lag of the `control_command` message (messages are published at approx. 40Hz with a period ranging from 0.01s to 0.05s). Since the state estimate is published at 100Hz, control commands should be published at a similar frequency.
Adding this transport hint disables [Nagle's Algorithm](https://www.extrahop.com/company/blog/2016/tcp-nodelay-nagle-quickack-best-practices/), and results in control commands being published at 100Hz. 