### PR TITLE
Solved a numerical instability in the InverseThrustMappingFunction

### DIFF
--- a/bridges/sbus_bridge/src/thrust_mapping.cpp
+++ b/bridges/sbus_bridge/src/thrust_mapping.cpp
@@ -54,11 +54,8 @@ uint16_t CollectiveThrustMapping::inverseThrustMapping(
     }
   }
 
-  const uint16_t cmd = (-thrust_map_b_
-      + sqrt(
-          thrust_map_b_ * thrust_map_b_
-              - 4.0 * thrust_map_a_ * (thrust_map_c_ - thrust_applied)))
-      / (2.0 * thrust_map_a_);
+  //Citardauq Formula: Gives a numerically stable solution of the quadratic equation for thrust_map_a ~ 0, which is not the case for the standard formula.
+    const uint16_t cmd = 2.0 * (thrust_map_c_ - thrust_applied) / (-thrust_map_b_ - sqrt(thrust_map_b_ * thrust_map_b_ - 4.0 * thrust_map_a_ * (thrust_map_c_ - thrust_applied)));
 
   return cmd;
 }


### PR DESCRIPTION
The usual formula for solving quadratic equations divides by zero when a=0 and is unprecise for a~0:
![image](https://user-images.githubusercontent.com/25506427/68599020-1ca3d980-04a0-11ea-92c2-1ec6c8a59095.png)

Therefore we should use the numerically stable version [1]. For our case of b >= 0 implies the formula as implemented in the code. 

A successful hover test on a flying quad has been done. 

\[1]: https://people.csail.mit.edu/bkph/articles/Quadratics.pdf